### PR TITLE
Changed prop name, to make Freeze grenades work again.

### DIFF
--- a/zr_grenade_effects_csgo.sp
+++ b/zr_grenade_effects_csgo.sp
@@ -396,7 +396,7 @@ public OnEntityCreated(entity, const String:classname[])
 
 public Grenade_SpawnPost(entity)
 {
-	new client = GetEntPropEnt(entity, Prop_Send, "m_hThrower");
+	new client = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
 	if (client == -1)return;
 	
 	new Action:result;


### PR DESCRIPTION
It looks like `m_hThrower` is not being set when smoke/decoy grenade spawns, so the `GetEntPropEnt` call will return **-1** and freeze grenades stop works. 

To make the plugin work we should use `m_hOwnerEntity` prop (tested on my server).